### PR TITLE
Fix study resources template iterable error

### DIFF
--- a/app.py
+++ b/app.py
@@ -3143,7 +3143,7 @@ def pdf_content(filename):
 
 # Route to get categories for a specific class
 @app.route('/api/categories/<int:class_id>')
-def get_categories_for_class(class_id):
+def api_get_categories_for_class(class_id):
     try:
         conn = sqlite3.connect('users.db')
         c = conn.cursor()


### PR DESCRIPTION
Rename Flask route `get_categories_for_class` to `api_get_categories_for_class` to resolve a naming conflict.

The `study_resources` function was inadvertently calling the Flask route function (which returns a `Response` object) instead of the `get_categories_for_class` function imported from `auth_handler.py` (which returns iterable data). This naming conflict caused a `TypeError: 'Response' object is not iterable` when rendering the template.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c044b8d-53a6-4387-a55d-082656ed181c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5c044b8d-53a6-4387-a55d-082656ed181c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

