### PR TITLE
Add live class container and reposition controls

### DIFF
--- a/join_class.html
+++ b/join_class.html
@@ -87,6 +87,8 @@
     body.dark-mode .tab-container {
       border-bottom-color: #3a3a4a;
     }
+    .live-watch-container { width: 100%; max-width: 680px; background: #fff; border: 1px solid #e0e7ff; border-radius: 12px; box-shadow: 0 6px 24px rgba(100,100,255,0.12); padding: 0.8rem; margin-bottom: 1.5rem; }
+    body.dark-mode .live-watch-container { background: #232946; border-color: #3a3a4a; box-shadow: 0 6px 24px rgba(0,0,0,0.3); }
   </style>
 </head>
 <body>
@@ -95,6 +97,7 @@
       <h3 style="color:#6a82fb; margin-bottom:1rem;">Live Class (Student View)</h3>
       <video id="remoteVideo" class="video-player" autoplay playsinline style="margin-bottom:1rem;"></video>
       <div id="viewerStatus" style="margin-bottom:1rem; color:#6a82fb;"></div>
+      <div class="live-watch-container">
       {% set is_youtube = 'youtube.com' in meeting_url or 'youtu.be' in meeting_url %}
       {% if is_youtube %}
         {% set youtube_id = None %}
@@ -114,6 +117,7 @@
           Your browser does not support the video tag.
         </video>
       {% endif %}
+      </div>
       <div class="class-info">
         <h2 class="class-title">{{ topic or 'Live Class' }}</h2>
         <p class="class-description">{{ description or '' }}</p>
@@ -121,11 +125,11 @@
       </div>
     </div>
     <div class="info-section">
-      <div class="tab-container" style="display:flex; margin-bottom: 1rem; border-bottom: 2px solid #e0e7ff;">
+      <div class="tab-container" style="display:flex; justify-content:flex-end; gap:0.5rem; margin-bottom: 1rem; border-bottom: 2px solid #e0e7ff;">
         <button class="tab-btn active" onclick="showTab('chat')">Chat</button>
         <button class="tab-btn" onclick="showTab('polls')">Polls</button>
         <button class="tab-btn" onclick="showTab('doubts')">Doubts</button>
-        <button id="darkModeToggle" class="btn btn-primary" style="min-width:160px; margin-left: auto;">Toggle Dark Mode</button>
+        <button id="darkModeToggle" class="btn btn-primary" style="min-width:160px;">Toggle Dark Mode</button>
       </div>
       <!-- Chat Tab -->
       <div id="chat-tab" class="tab-content active">

--- a/join_class_host.html
+++ b/join_class_host.html
@@ -15,8 +15,8 @@
     .back-link { color: #6a82fb; text-decoration: none; font-weight: 500; }
     .back-link:hover { text-decoration: underline; }
     
-    .tab-container { display: flex; margin-bottom: 1rem; border-bottom: 2px solid #e0e7ff; }
-    .tab-btn { flex: 1; padding: 0.8rem; background: none; border: none; cursor: pointer; font-weight: 500; color: #666; transition: all 0.2s; }
+    .tab-container { display: flex; margin-bottom: 1rem; border-bottom: 2px solid #e0e7ff; justify-content: flex-end; gap: 0.5rem; }
+    .tab-btn { padding: 0.8rem; background: none; border: none; cursor: pointer; font-weight: 500; color: #666; transition: all 0.2s; }
     .tab-btn.active { color: #6a82fb; border-bottom: 2px solid #6a82fb; }
     .tab-content { display: none; }
     .tab-content.active { display: block; }
@@ -137,6 +137,8 @@
     body.dark-mode .tab-container {
       border-bottom-color: #3a3a4a;
     }
+    .live-watch-container { width: 100%; max-width: 680px; background: #fff; border: 1px solid #e0e7ff; border-radius: 12px; box-shadow: 0 6px 24px rgba(100,100,255,0.12); padding: 0.8rem; margin-bottom: 1.5rem; }
+    body.dark-mode .live-watch-container { background: #232946; border-color: #3a3a4a; box-shadow: 0 6px 24px rgba(0,0,0,0.3); }
   </style>
 </head>
 <body>
@@ -145,6 +147,7 @@
       <h3 style="color:#6a82fb; margin-bottom:1rem;">Live Class (Host View)</h3>
       <video id="remoteVideo" class="video-player" autoplay playsinline style="margin-bottom:1rem;"></video>
       <div id="viewerStatus" style="margin-bottom:1rem; color:#6a82fb;"></div>
+      <div class="live-watch-container">
       {% set is_youtube = 'youtube.com' in meeting_url or 'youtu.be' in meeting_url %}
       {% if is_youtube %}
         {% set youtube_id = None %}
@@ -164,6 +167,7 @@
           Your browser does not support the video tag.
         </video>
       {% endif %}
+      </div>
       <div class="class-info">
         <h2 class="class-title">{{ topic or 'Live Class' }}</h2>
         <p class="class-description">{{ description or '' }}</p>
@@ -176,7 +180,7 @@
         <button class="tab-btn" onclick="showTab('polls')">Polls</button>
         <button class="tab-btn" onclick="showTab('doubts')">Doubts</button>
         <button class="tab-btn" onclick="showTab('controls')">Controls</button>
-        <button id="darkModeToggle" class="btn btn-primary" style="min-width:160px; margin-left: auto;">Toggle Dark Mode</button>
+        <button id="darkModeToggle" class="btn btn-primary" style="min-width:160px;">Toggle Dark Mode</button>
       </div>
       
       <!-- Chat Tab -->


### PR DESCRIPTION
Add a "watch live" container to embedded players and right-align tab controls on join class pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf0c155f-84fa-4aab-a8f3-61fb74bd5d25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cf0c155f-84fa-4aab-a8f3-61fb74bd5d25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

