### PR TITLE
Remove navbar toggle mode

### DIFF
--- a/auth.html
+++ b/auth.html
@@ -15,12 +15,6 @@
         </div>
         <ul class="nav-links">
           <li><a href="/">Home</a></li>
-          <!-- Dark Mode Toggle -->
-          <li>
-            <button id="darkModeToggle" class="btn btn-secondary" style="background: transparent; border: 1px solid #6a82fb; color: #6a82fb; padding: 0.5rem 1rem; border-radius: 8px; cursor: pointer; transition: all 0.3s ease;">
-              🌙 Dark Mode
-            </button>
-          </li>
         </ul>
         <button class="hamburger">
             <span class="bar"></span>

--- a/forum.html
+++ b/forum.html
@@ -69,14 +69,8 @@
             <li><a href="/logout" class="btn btn-primary">Logout</a></li>
           {% else %}
             <li><a href="/auth" class="btn btn-primary">Login</a></li>
-          {% endif %}
-          <!-- Dark Mode Toggle -->
-          <li>
-            <button id="darkModeToggle" class="btn btn-secondary" style="background: transparent; border: 1px solid #6a82fb; color: #6a82fb; padding: 0.5rem 1rem; border-radius: 8px; cursor: pointer; transition: all 0.3s ease;">
-              🌙 Dark Mode
-            </button>
-          </li>
-        </ul>
+                     {% endif %}
+</ul>
         <button class="hamburger">
             <span class="bar"></span>
             <span class="bar"></span>

--- a/index.html
+++ b/index.html
@@ -51,12 +51,6 @@
           {% else %}
             <li><a href="/auth" class="btn btn-primary">Login</a></li>
           {% endif %}
-          <!-- Dark Mode Toggle -->
-          <li>
-            <button id="darkModeToggle" class="btn btn-secondary" style="background: transparent; border: 1px solid #6a82fb; color: #6a82fb; padding: 0.5rem 1rem; border-radius: 8px; cursor: pointer; transition: all 0.3s ease;">
-              🌙 Dark Mode
-            </button>
-          </li>
       </ul>
       <button class="hamburger">
         <span class="bar"></span>

--- a/online-class.html
+++ b/online-class.html
@@ -43,18 +43,12 @@
             </div>
           </li>
           {% endif %}
-          {% if username %}
-            <li><a href="/logout" class="btn btn-primary">Logout</a></li>
-          {% else %}
-          <li><a href="/auth" class="btn btn-primary">Login</a></li>
-          {% endif %}
-          <!-- Dark Mode Toggle -->
-          <li>
-            <button id="darkModeToggle" class="btn btn-secondary" style="background: transparent; border: 1px solid #6a82fb; color: #6a82fb; padding: 0.5rem 1rem; border-radius: 8px; cursor: pointer; transition: all 0.3s ease;">
-              🌙 Dark Mode
-            </button>
-          </li>
-        </ul>
+                     {% if username %}
+             <li><a href="/logout" class="btn btn-primary">Logout</a></li>
+           {% else %}
+           <li><a href="/auth" class="btn btn-primary">Login</a></li>
+           {% endif %}
+</ul>
       </div>
     </nav>
     <header class="hero-section">

--- a/profile.html
+++ b/profile.html
@@ -576,14 +576,8 @@
         <li><a href="/online-class">Live Class</a></li>
         <li><a href="/study-resources">Study Resources</a></li>
         <li><a href="/forum">Forum</a></li>
-        <li><a href="/logout" class="btn btn-primary">Logout</a></li>
-        <!-- Dark Mode Toggle -->
-        <li>
-          <button id="darkModeToggle" class="btn btn-secondary" style="background: transparent; border: 1px solid #6a82fb; color: #6a82fb; padding: 0.5rem 1rem; border-radius: 8px; cursor: pointer; transition: all 0.3s ease;">
-            🌙 Dark Mode
-          </button>
-        </li>
-      </ul>
+                 <li><a href="/logout" class="btn btn-primary">Logout</a></li>
+</ul>
     </div>
   </nav>
   

--- a/study-resources.html
+++ b/study-resources.html
@@ -145,14 +145,8 @@
             <li><a href="/logout" class="btn btn-primary">Logout</a></li>
           {% else %}
             <li><a href="/auth" class="btn btn-primary">Login</a></li>
-          {% endif %}
-          <!-- Dark Mode Toggle -->
-          <li>
-            <button id="darkModeToggle" class="btn btn-secondary" style="background: transparent; border: 1px solid #6a82fb; color: #6a82fb; padding: 0.5rem 1rem; border-radius: 8px; cursor: pointer; transition: all 0.3s ease;">
-              🌙 Dark Mode
-            </button>
-          </li>
-        </ul>
+                     {% endif %}
+</ul>
         <button class="hamburger">
             <span class="bar"></span>
             <span class="bar"></span>

--- a/user_info.html
+++ b/user_info.html
@@ -223,7 +223,6 @@
       </div>
       <ul class="nav-links">
         <li><a href="/admin">Admin Panel</a></li>
-        <li><button id="darkModeToggle" class="btn btn-primary" style="min-width:160px;">Toggle Dark Mode</button></li>
         <li><a href="/logout" class="btn btn-primary">Logout</a></li>
       </ul>
     </div>


### PR DESCRIPTION
Remove redundant dark mode toggle from the navbar across all pages as per-page toggles exist.

---
<a href="https://cursor.com/background-agent?bcId=bc-a27d4cc6-b4bf-4b3b-9b91-da35f300b7ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a27d4cc6-b4bf-4b3b-9b91-da35f300b7ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

