### PR TITLE
Add topper scholars 2024-25 pictures

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
     <!-- Student Achievements Section -->
     <section class="wall-of-fame-section" style="background: linear-gradient(135deg, #ffd700 0%, #ffed4e 100%); padding: 3rem 0; margin: 2rem 0;">
       <div class="container">
-        <h2 style="text-align: center; color: #232946; font-size: 2.5rem; margin-bottom: 1rem;">SUNRISE EDUCATION CENTRE SCHOLARS - 2023-24</h2>
+        <h2 style="text-align: center; color: #232946; font-size: 2.5rem; margin-bottom: 1rem;">SUNRISE EDUCATION CENTRE SCHOLARS - 2024-25</h2>
         <p style="text-align: center; color: #232946; font-size: 1.1rem; margin-bottom: 2rem; font-weight: 600;">Er. Mohit Nariyani</p>
         
         <!-- Top Achievements Grid -->
@@ -81,96 +81,54 @@
           
           <!-- 2023-2024 Scholars Card -->
           <div class="achievement-card" style="background: rgba(255,255,255,0.95); border-radius: 20px; padding: 2rem; box-shadow: 0 8px 32px rgba(0,0,0,0.1); text-align: center;">
-            <h3 style="color: #232946; margin-bottom: 1rem; font-size: 1.4rem; font-weight: 700;">🎓 Academic Year 2023-2024</h3>
+            <h3 style="color: #232946; margin-bottom: 1rem; font-size: 1.4rem; font-weight: 700;">🎓 Academic Year 2024-2025</h3>
             <div style="background: rgba(106,130,251,0.2); padding: 0.5rem; border-radius: 10px; margin-bottom: 1rem;">
               <strong style="color: #232946;">Class X - CBSE Board</strong>
             </div>
-            <img src="student_achievements/2023_2024_scholars.jpeg" alt="2023-2024 Scholars" style="width: 100%; max-width: 350px; height: auto; border-radius: 15px; margin-bottom: 1.5rem; box-shadow: 0 4px 16px rgba(0,0,0,0.1);">
+            <img src="student_achievements/2024_2025_achievements.jpeg" alt="2024-2025 Scholars" style="width: 100%; max-width: 350px; height: auto; border-radius: 15px; margin-bottom: 1.5rem; box-shadow: 0 4px 16px rgba(0,0,0,0.1);">
             
             <!-- Top Performers Grid -->
             <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 0.8rem;">
               <div class="student-card" style="background: rgba(106,130,251,0.15); padding: 1rem; border-radius: 12px; border: 2px solid rgba(106,130,251,0.3);">
-                <div style="font-weight: 700; color: #232946; font-size: 0.9rem; margin-bottom: 0.3rem;">DIVYA THAWANI</div>
-                <div style="font-size: 1.3rem; font-weight: 700; color: #6a82fb; margin-bottom: 0.2rem;">98/100</div>
-                <div style="color: #232946; font-size: 0.8rem; margin-bottom: 0.2rem;">X-Basic MATHS</div>
-                <div style="color: #666; font-size: 0.75rem;">Class X - 2024</div>
-              </div>
-              
-              <div class="student-card" style="background: rgba(106,130,251,0.15); padding: 1rem; border-radius: 12px; border: 2px solid rgba(106,130,251,0.3);">
-                <div style="font-weight: 700; color: #232946; font-size: 0.9rem; margin-bottom: 0.3rem;">HARSHITA KEWALRAMANI</div>
-                <div style="font-size: 1.3rem; font-weight: 700; color: #6a82fb; margin-bottom: 0.2rem;">98/100</div>
-                <div style="color: #232946; font-size: 0.8rem; margin-bottom: 0.2rem;">X-Basic MATHS</div>
-                <div style="color: #666; font-size: 0.75rem;">Class X - 2024</div>
-              </div>
-              
-              <div class="student-card" style="background: rgba(106,130,251,0.15); padding: 1rem; border-radius: 12px; border: 2px solid rgba(106,130,251,0.3);">
-                <div style="font-weight: 700; color: #232946; font-size: 0.9rem; margin-bottom: 0.3rem;">HARSHIL RAMRAKHYANI</div>
-                <div style="font-size: 1.3rem; font-weight: 700; color: #6a82fb; margin-bottom: 0.2rem;">94/100</div>
+                <div style="font-weight: 700; color: #232946; font-size: 0.9rem; margin-bottom: 0.3rem;">JIYA MENGHANI</div>
+                <div style="font-size: 1.3rem; font-weight: 700; color: #6a82fb; margin-bottom: 0.2rem;">100/100</div>
                 <div style="color: #232946; font-size: 0.8rem; margin-bottom: 0.2rem;">X-Standard MATHS</div>
-                <div style="color: #666; font-size: 0.75rem;">Class X - 2024</div>
+                <div style="color: #666; font-size: 0.75rem;">Class X - 2025 • City Topper (4th Rank) • 98%</div>
               </div>
               
               <div class="student-card" style="background: rgba(106,130,251,0.15); padding: 1rem; border-radius: 12px; border: 2px solid rgba(106,130,251,0.3);">
-                <div style="font-weight: 700; color: #232946; font-size: 0.9rem; margin-bottom: 0.3rem;">SAKSHI LEELANI</div>
+                <div style="font-weight: 700; color: #232946; font-size: 0.9rem; margin-bottom: 0.3rem;">MAYUR SABNANI</div>
+                <div style="font-size: 1.3rem; font-weight: 700; color: #6a82fb; margin-bottom: 0.2rem;">97/100</div>
+                <div style="color: #232946; font-size: 0.8rem; margin-bottom: 0.2rem;">X-Standard MATHS</div>
+                <div style="color: #666; font-size: 0.75rem;">Class X - 2025</div>
+              </div>
+              
+              <div class="student-card" style="background: rgba(106,130,251,0.15); padding: 1rem; border-radius: 12px; border: 2px solid rgba(106,130,251,0.3);">
+                <div style="font-weight: 700; color: #232946; font-size: 0.9rem; margin-bottom: 0.3rem;">RITIK MOTWANI</div>
                 <div style="font-size: 1.3rem; font-weight: 700; color: #6a82fb; margin-bottom: 0.2rem;">93/100</div>
                 <div style="color: #232946; font-size: 0.8rem; margin-bottom: 0.2rem;">X-Standard MATHS</div>
-                <div style="color: #666; font-size: 0.75rem;">Class X - 2024</div>
+                <div style="color: #666; font-size: 0.75rem;">Class X - 2025</div>
               </div>
               
               <div class="student-card" style="background: rgba(106,130,251,0.15); padding: 1rem; border-radius: 12px; border: 2px solid rgba(106,130,251,0.3);">
-                <div style="font-weight: 700; color: #232946; font-size: 0.9rem; margin-bottom: 0.3rem;">SAMEER SATANI</div>
-                <div style="font-size: 1.3rem; font-weight: 700; color: #6a82fb; margin-bottom: 0.2rem;">88/100</div>
-                <div style="color: #232946; font-size: 0.8rem; margin-bottom: 0.2rem;">XII-Core MATHS</div>
-                <div style="color: #666; font-size: 0.75rem;">Class XII - 2024</div>
-              </div>
-              
-              <div class="student-card" style="background: rgba(106,130,251,0.15); padding: 1rem; border-radius: 12px; border: 2px solid rgba(106,130,251,0.3);">
-                <div style="font-weight: 700; color: #232946; font-size: 0.9rem; margin-bottom: 0.3rem;">SAKSHI HARCHANDANI</div>
+                <div style="font-weight: 700; color: #232946; font-size: 0.9rem; margin-bottom: 0.3rem;">UDAY POPTANI</div>
                 <div style="font-size: 1.3rem; font-weight: 700; color: #6a82fb; margin-bottom: 0.2rem;">87/100</div>
                 <div style="color: #232946; font-size: 0.8rem; margin-bottom: 0.2rem;">X-Standard MATHS</div>
-                <div style="color: #666; font-size: 0.75rem;">Class X - 2024</div>
+                <div style="color: #666; font-size: 0.75rem;">Class X - 2025</div>
               </div>
               
               <div class="student-card" style="background: rgba(106,130,251,0.15); padding: 1rem; border-radius: 12px; border: 2px solid rgba(106,130,251,0.3);">
-                <div style="font-weight: 700; color: #232946; font-size: 0.9rem; margin-bottom: 0.3rem;">YASHIKA JANYANI</div>
-                <div style="font-size: 1.3rem; font-weight: 700; color: #6a82fb; margin-bottom: 0.2rem;">87/100</div>
+                <div style="font-weight: 700; color: #232946; font-size: 0.9rem; margin-bottom: 0.3rem;">YATHARTH VERMA</div>
+                <div style="font-size: 1.3rem; font-weight: 700; color: #6a82fb; margin-bottom: 0.2rem;">85/100</div>
                 <div style="color: #232946; font-size: 0.8rem; margin-bottom: 0.2rem;">X-Standard MATHS</div>
-                <div style="color: #666; font-size: 0.75rem;">Class X - 2024</div>
+                <div style="color: #666; font-size: 0.75rem;">Class X - 2025</div>
               </div>
               
               <div class="student-card" style="background: rgba(106,130,251,0.15); padding: 1rem; border-radius: 12px; border: 2px solid rgba(106,130,251,0.3);">
-                <div style="font-weight: 700; color: #232946; font-size: 0.9rem; margin-bottom: 0.3rem;">PRAJWAL HEMNANI</div>
-                <div style="font-size: 1.3rem; font-weight: 700; color: #6a82fb; margin-bottom: 0.2rem;">84/100</div>
-                <div style="color: #232946; font-size: 0.8rem; margin-bottom: 0.2rem;">X-Standard MATHS</div>
-                <div style="color: #666; font-size: 0.75rem;">Class X - 2024</div>
-              </div>
-              
-              <div class="student-card" style="background: rgba(106,130,251,0.15); padding: 1rem; border-radius: 12px; border: 2px solid rgba(106,130,251,0.3);">
-                <div style="font-weight: 700; color: #232946; font-size: 0.9rem; margin-bottom: 0.3rem;">SUMIT BHARWANI</div>
-                <div style="font-size: 1.3rem; font-weight: 700; color: #6a82fb; margin-bottom: 0.2rem;">84/100</div>
+                <div style="font-weight: 700; color: #232946; font-size: 0.9rem; margin-bottom: 0.3rem;">PRANAV LALWANI</div>
+                <div style="font-size: 1.3rem; font-weight: 700; color: #6a82fb; margin-bottom: 0.2rem;">85/100</div>
                 <div style="color: #232946; font-size: 0.8rem; margin-bottom: 0.2rem;">X-Basic MATHS</div>
-                <div style="color: #666; font-size: 0.75rem;">Class X - 2024</div>
-              </div>
-              
-              <div class="student-card" style="background: rgba(106,130,251,0.15); padding: 1rem; border-radius: 12px; border: 2px solid rgba(106,130,251,0.3);">
-                <div style="font-weight: 700; color: #232946; font-size: 0.9rem; margin-bottom: 0.3rem;">JAGRATI LALCHANDANI</div>
-                <div style="font-size: 1.3rem; font-weight: 700; color: #6a82fb; margin-bottom: 0.2rem;">82/100</div>
-                <div style="color: #232946; font-size: 0.8rem; margin-bottom: 0.2rem;">XII-Core MATHS</div>
-                <div style="color: #666; font-size: 0.75rem;">Class XII - 2024</div>
-              </div>
-              
-              <div class="student-card" style="background: rgba(106,130,251,0.15); padding: 1rem; border-radius: 12px; border: 2px solid rgba(106,130,251,0.3);">
-                <div style="font-weight: 700; color: #232946; font-size: 0.9rem; margin-bottom: 0.3rem;">DHEERAJ KHUSHLANI</div>
-                <div style="font-size: 1.3rem; font-weight: 700; color: #6a82fb; margin-bottom: 0.2rem;">81/100</div>
-                <div style="color: #232946; font-size: 0.8rem; margin-bottom: 0.2rem;">X-Standard MATHS</div>
-                <div style="color: #666; font-size: 0.75rem;">Class X - 2024</div>
-              </div>
-              
-              <div class="student-card" style="background: rgba(106,130,251,0.15); padding: 1rem; border-radius: 12px; border: 2px solid rgba(106,130,251,0.3);">
-                <div style="font-weight: 700; color: #232946; font-size: 0.9rem; margin-bottom: 0.3rem;">PRANJAL RAISINGHANI</div>
-                <div style="font-size: 1.3rem; font-weight: 700; color: #6a82fb; margin-bottom: 0.2rem;">81/100</div>
-                <div style="color: #232946; font-size: 0.8rem; margin-bottom: 0.2rem;">X-Basic MATHS</div>
-                <div style="color: #666; font-size: 0.75rem;">Class X - 2024</div>
+                <div style="color: #666; font-size: 0.75rem;">Class X - 2025</div>
               </div>
             </div>
           </div>
@@ -324,116 +282,62 @@
     </section>
     <!-- Wall of Fame Section -->
     <section id="wall-of-fame" style="margin:3rem 0;">
-      <h2 style="text-align:center; margin-bottom:1rem; color:#6a82fb; font-size:2.2rem;">SUNRISE EDUCATION CENTRE SCHOLARS - 2023-24</h2>
+      <h2 style="text-align:center; margin-bottom:1rem; color:#6a82fb; font-size:2.2rem;">SUNRISE EDUCATION CENTRE SCHOLARS - 2024-25</h2>
       <p style="text-align:center; margin-bottom:2rem; color:#6a82fb; font-size:1.1rem; font-weight:600;">Er. Mohit Nariyani</p>
       <div class="fame-slider-container">
         <button class="fame-arrow fame-arrow-left" onclick="slideFame(-1)">&#8592;</button>
         <div class="fame-slider" id="fameSlider">
           <div class="fame-card">
             <div class="fame-image-wrapper">
-              <img src="img/yash.jpg" alt="DIVYA THAWANI" class="fame-photo">
+              <img src="student_achievements/2024_2025_achievements.jpeg" alt="JIYA MENGHANI" class="fame-photo">
               <div class="fame-overlay">
-                <div class="fame-name">DIVYA THAWANI</div>
-                <div class="fame-meta"><span>98/100</span><span>X-Basic MATHS</span><span>2023-24</span></div>
+                <div class="fame-name">JIYA MENGHANI</div>
+                <div class="fame-meta"><span>100/100</span><span>X-Standard MATHS</span><span>2024-25</span></div>
               </div>
             </div>
           </div>
           <div class="fame-card">
             <div class="fame-image-wrapper">
-              <img src="img/IMG-20250706-WA0000.jpg" alt="HARSHITA KEWALRAMANI" class="fame-photo">
+              <img src="img/yash.jpg" alt="MAYUR SABNANI" class="fame-photo">
               <div class="fame-overlay">
-                <div class="fame-name">HARSHITA KEWALRAMANI</div>
-                <div class="fame-meta"><span>98/100</span><span>X-Basic MATHS</span><span>2023-24</span></div>
+                <div class="fame-name">MAYUR SABNANI</div>
+                <div class="fame-meta"><span>97/100</span><span>X-Standard MATHS</span><span>2024-25</span></div>
               </div>
             </div>
           </div>
           <div class="fame-card">
             <div class="fame-image-wrapper">
-              <img src="img/yash.jpg" alt="HARSHIL RAMRAKHYANI" class="fame-photo">
+              <img src="img/IMG-20250706-WA0000.jpg" alt="RITIK MOTWANI" class="fame-photo">
               <div class="fame-overlay">
-                <div class="fame-name">HARSHIL RAMRAKHYANI</div>
-                <div class="fame-meta"><span>94/100</span><span>X-Standard MATHS</span><span>2023-24</span></div>
+                <div class="fame-name">RITIK MOTWANI</div>
+                <div class="fame-meta"><span>93/100</span><span>X-Standard MATHS</span><span>2024-25</span></div>
               </div>
             </div>
           </div>
           <div class="fame-card">
             <div class="fame-image-wrapper">
-              <img src="img/IMG-20250706-WA0000.jpg" alt="SAKSHI LEELANI" class="fame-photo">
+              <img src="img/yash.jpg" alt="UDAY POPTANI" class="fame-photo">
               <div class="fame-overlay">
-                <div class="fame-name">SAKSHI LEELANI</div>
-                <div class="fame-meta"><span>93/100</span><span>X-Standard MATHS</span><span>2023-24</span></div>
+                <div class="fame-name">UDAY POPTANI</div>
+                <div class="fame-meta"><span>87/100</span><span>X-Standard MATHS</span><span>2024-25</span></div>
               </div>
             </div>
           </div>
           <div class="fame-card">
             <div class="fame-image-wrapper">
-              <img src="img/yash.jpg" alt="SAMEER SATANI" class="fame-photo">
+              <img src="img/IMG-20250706-WA0000.jpg" alt="YATHARTH VERMA" class="fame-photo">
               <div class="fame-overlay">
-                <div class="fame-name">SAMEER SATANI</div>
-                <div class="fame-meta"><span>88/100</span><span>XII-Core MATHS</span><span>2023-24</span></div>
+                <div class="fame-name">YATHARTH VERMA</div>
+                <div class="fame-meta"><span>85/100</span><span>X-Standard MATHS</span><span>2024-25</span></div>
               </div>
             </div>
           </div>
           <div class="fame-card">
             <div class="fame-image-wrapper">
-              <img src="img/IMG-20250706-WA0000.jpg" alt="SAKSHI HARCHANDANI" class="fame-photo">
+              <img src="img/yash.jpg" alt="PRANAV LALWANI" class="fame-photo">
               <div class="fame-overlay">
-                <div class="fame-name">SAKSHI HARCHANDANI</div>
-                <div class="fame-meta"><span>87/100</span><span>X-Standard MATHS</span><span>2023-24</span></div>
-              </div>
-            </div>
-          </div>
-          <div class="fame-card">
-            <div class="fame-image-wrapper">
-              <img src="img/yash.jpg" alt="YASHIKA JANYANI" class="fame-photo">
-              <div class="fame-overlay">
-                <div class="fame-name">YASHIKA JANYANI</div>
-                <div class="fame-meta"><span>87/100</span><span>X-Standard MATHS</span><span>2023-24</span></div>
-              </div>
-            </div>
-          </div>
-          <div class="fame-card">
-            <div class="fame-image-wrapper">
-              <img src="img/IMG-20250706-WA0000.jpg" alt="PRAJWAL HEMNANI" class="fame-photo">
-              <div class="fame-overlay">
-                <div class="fame-name">PRAJWAL HEMNANI</div>
-                <div class="fame-meta"><span>84/100</span><span>X-Standard MATHS</span><span>2023-24</span></div>
-              </div>
-            </div>
-          </div>
-          <div class="fame-card">
-            <div class="fame-image-wrapper">
-              <img src="img/yash.jpg" alt="SUMIT BHARWANI" class="fame-photo">
-              <div class="fame-overlay">
-                <div class="fame-name">SUMIT BHARWANI</div>
-                <div class="fame-meta"><span>84/100</span><span>X-Basic MATHS</span><span>2023-24</span></div>
-              </div>
-            </div>
-          </div>
-          <div class="fame-card">
-            <div class="fame-image-wrapper">
-              <img src="img/IMG-20250706-WA0000.jpg" alt="JAGRATI LALCHANDANI" class="fame-photo">
-              <div class="fame-overlay">
-                <div class="fame-name">JAGRATI LALCHANDANI</div>
-                <div class="fame-meta"><span>82/100</span><span>XII-Core MATHS</span><span>2023-24</span></div>
-              </div>
-            </div>
-          </div>
-          <div class="fame-card">
-            <div class="fame-image-wrapper">
-              <img src="img/yash.jpg" alt="DHEERAJ KHUSHLANI" class="fame-photo">
-              <div class="fame-overlay">
-                <div class="fame-name">DHEERAJ KHUSHLANI</div>
-                <div class="fame-meta"><span>81/100</span><span>X-Standard MATHS</span><span>2023-24</span></div>
-              </div>
-            </div>
-          </div>
-          <div class="fame-card">
-            <div class="fame-image-wrapper">
-              <img src="img/IMG-20250706-WA0000.jpg" alt="PRANJAL RAISINGHANI" class="fame-photo">
-              <div class="fame-overlay">
-                <div class="fame-name">PRANJAL RAISINGHANI</div>
-                <div class="fame-meta"><span>81/100</span><span>X-Basic MATHS</span><span>2023-24</span></div>
+                <div class="fame-name">PRANAV LALWANI</div>
+                <div class="fame-meta"><span>85/100</span><span>X-Basic MATHS</span><span>2024-25</span></div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Update 'SUNRISE EDUCATION CENTRE SCHOLARS' section to display 2024-25 toppers and their achievements.

---
<a href="https://cursor.com/background-agent?bcId=bc-81931102-0643-42f6-8f44-c60efce5c333">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-81931102-0643-42f6-8f44-c60efce5c333">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

