### PR TITLE
Check link placement and old css

### DIFF
--- a/online-class.html
+++ b/online-class.html
@@ -9,13 +9,12 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap">
     <link rel="stylesheet" href="style.css" />
     <link rel="stylesheet" href="floating-navbar.css" />
-    <link rel="stylesheet" href="forum.css" />
     <link rel="stylesheet" href="online-class.css" />
 
   </head>
   <body>
     <!-- Floating Navbar -->
-    <nav class="floating-navbar">
+    <nav class="floating-navbar black-glass">
         <button class="hamburger" aria-label="Menu" aria-expanded="false">
             <span class="bar"></span>
             <span class="bar"></span>


### PR DESCRIPTION
Remove `forum.css` and apply `black-glass` variant to the navbar in `online-class.html` to fix old CSS styling and ensure consistent navbar appearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-2335a0d9-1ab4-4a45-8fab-0fcd51a3a521">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2335a0d9-1ab4-4a45-8fab-0fcd51a3a521">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

