### PR TITLE
Add coaching logo to auth page background

### DIFF
--- a/auth.html
+++ b/auth.html
@@ -30,6 +30,17 @@
             padding: 2rem;
             position: relative;
         }
+        
+        /* Watermark logo background */
+        .auth-page::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: url('attached_assets/image_1750584670920.png') center/60vmin no-repeat;
+            opacity: 0.07;
+            pointer-events: none;
+            z-index: 0;
+        }
 
         /* Hide any navbar elements that might be created by CSS */
         .navbar,


### PR DESCRIPTION
Add coaching logo as a subtle background watermark to the authentication page.

---
<a href="https://cursor.com/background-agent?bcId=bc-69927b9e-4ce6-4b30-ae92-dab807952a6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-69927b9e-4ce6-4b30-ae92-dab807952a6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

