### PR TITLE
Fit hero panel on forum and class pages

### DIFF
--- a/forum.html
+++ b/forum.html
@@ -410,6 +410,12 @@
                 max-height: 60vh;
             }
         }
+
+        /* Fit hero panel: full-bleed and no extra spacing */
+        .hero-section.hero-modern {
+            padding: 0 !important;
+            min-height: 100vh; /* ensure viewport fit */
+        }
     </style>
 </head>
 <body class="forum-page" data-user-role="{{ role|default('') }}">

--- a/online-class.html
+++ b/online-class.html
@@ -541,6 +541,12 @@
             
             .class-cards-grid { grid-template-columns: 1fr; gap: 1.5rem; }
         }
+
+        /* Fit hero panel: full-bleed and no extra spacing */
+        .hero-section.hero-modern {
+            padding: 0 !important;
+            min-height: 100vh; /* ensure viewport fit */
+        }
     </style>
   </head>
   <body class="online-class-page">


### PR DESCRIPTION
Remove extra space from hero panels in `forum.html` and `online-class.html` to make them full-bleed and fit the viewport.

---
<a href="https://cursor.com/background-agent?bcId=bc-9fde9391-7116-4dc0-b350-998d7159c40e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9fde9391-7116-4dc0-b350-998d7159c40e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

